### PR TITLE
fix: resolve Ink `id:` speakers when characters are unknown at conversion time (#123)

### DIFF
--- a/src/loader/importer.ts
+++ b/src/loader/importer.ts
@@ -1,6 +1,6 @@
 import { HashtagCommands } from "@/handlers";
 import { convertInkToJson } from "@/loader/ink-to-pixivn";
-import type { LoaderSharedType } from "@/loader/type";
+import type { CharacterIdSource, LoaderSharedType } from "@/loader/type";
 import { init, type PixiVNJson } from "@drincs/pixi-vn-json";
 import { importPixiVNJson } from "@drincs/pixi-vn-json/interpreter";
 
@@ -17,9 +17,14 @@ import { importPixiVNJson } from "@drincs/pixi-vn-json/interpreter";
  * })
  * ```
  * @param texts string or array of strings written in ink language
+ * @param options.characters characters recognised when splitting `characterId: text` speakers, in
+ * addition to `RegisteredCharacters` (pass when importing before characters are registered)
  * @returns
  */
-export async function importInkText(texts: string | string[]): Promise<string[]> {
+export async function importInkText(
+    texts: string | string[],
+    options: { characters?: readonly CharacterIdSource[] } = {},
+): Promise<string[]> {
     if (!Array.isArray(texts)) {
         texts = [texts];
     }
@@ -27,6 +32,7 @@ export async function importInkText(texts: string | string[]): Promise<string[]>
     const shared: LoaderSharedType = {
         functions: [],
         enums: {},
+        characters: options.characters,
     };
     const promises = texts.map(async (text) => {
         const data = convertInkToJson(text, shared);

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -6,3 +6,4 @@ export {
     convertInkToJson as convertInkText,
     convertInkToJson,
 } from "@/loader/ink-to-pixivn";
+export type { CharacterIdSource } from "@/loader/type";

--- a/src/loader/ink-to-pixivn.ts
+++ b/src/loader/ink-to-pixivn.ts
@@ -1,5 +1,5 @@
 import type InkStoryType from "@/interfaces/InkStoryType";
-import type { LoaderSharedType } from "@/loader/type";
+import type { CharacterIdSource, LoaderSharedType } from "@/loader/type";
 import { InkMapper } from "@/mapper";
 import { InkCompiler } from "@/parser";
 import type { CompileSharedType } from "@/parser/types";
@@ -7,6 +7,23 @@ import { logger } from "@/utils/log-utility";
 import type { PixiVNJson } from "@drincs/pixi-vn-json";
 import { ErrorType } from "inkjs/compiler/Parser/ErrorType";
 import JSON5 from "json5";
+
+/** Normalises character sources (ids or `{ id }` objects) into a set of ids, or `undefined` if empty. */
+export function normalizeCharacterIds(
+    characters?: readonly CharacterIdSource[],
+): ReadonlySet<string> | undefined {
+    if (!characters || characters.length === 0) {
+        return undefined;
+    }
+    const ids = new Set<string>();
+    for (const character of characters) {
+        const id = typeof character === "string" ? character : character?.id;
+        if (typeof id === "string" && id.length > 0) {
+            ids.add(id);
+        }
+    }
+    return ids.size > 0 ? ids : undefined;
+}
 
 /**
  * This function converts string written in ink language into the LabelJsonType.
@@ -46,5 +63,8 @@ export function convertInkToJson(
         return;
     }
     shared.enums = obj.listDefs || {};
-    return InkMapper.inkToJson(obj, shared);
+    return InkMapper.inkToJson(obj, {
+        ...shared,
+        characterIds: normalizeCharacterIds(options.characters),
+    });
 }

--- a/src/loader/type.ts
+++ b/src/loader/type.ts
@@ -1,3 +1,12 @@
 import type { CompileSharedType } from "@/parser/types";
 
-export type LoaderSharedType = Pick<CompileSharedType, "enums" | "functions">;
+/** A character id, or any object carrying one (e.g. a `CharacterInterface` / `RegisteredCharacters.values()`). */
+export type CharacterIdSource = string | { id: string };
+
+export type LoaderSharedType = Pick<CompileSharedType, "enums" | "functions"> & {
+    /**
+     * Characters recognised when splitting `characterId: text` speakers, in addition to the global
+     * `RegisteredCharacters` registry. Pass when converting before characters are registered.
+     */
+    characters?: readonly CharacterIdSource[];
+};

--- a/src/mapper/adding-elements.ts
+++ b/src/mapper/adding-elements.ts
@@ -170,7 +170,7 @@ function addConditionalElementStep(
             list[list.length - 1] = prevItem;
         }
         if (typeof item === "string") {
-            list.push(getDialog(getText(item)));
+            list.push(getDialog(getText(item), shared.characterIds));
         } else {
             list.push({
                 dialogue: item,
@@ -312,13 +312,13 @@ function addConditionalElementStep(
     }
 }
 
-function getDialog(text: string): PixiVNJsonLabelStep {
+function getDialog(text: string, characterIds?: ReadonlySet<string>): PixiVNJsonLabelStep {
     let character: string | undefined;
     if (text.includes(": ")) {
         const parts = text.split(": ");
         const c = parts[0];
         const t = parts.slice(1).join(": ");
-        if (RegisteredCharacters.has(c)) {
+        if (characterIds?.has(c) || RegisteredCharacters.has(c)) {
             character = c;
             text = t;
         }

--- a/src/mapper/index.ts
+++ b/src/mapper/index.ts
@@ -31,6 +31,7 @@ export namespace InkMapper {
             enums = {},
             functions = [],
             preDialog = {},
+            characterIds,
         } = shared;
         const result: PixiVNJson = {
             $schema: PIXIVNJSON_SCHEMA_URL,
@@ -41,6 +42,7 @@ export namespace InkMapper {
             enums,
             functions,
             preDialog,
+            characterIds,
         });
         if (result.labels && GLOBAL_DECL in result.labels) {
             const global = result.labels[GLOBAL_DECL];

--- a/src/mapper/types.ts
+++ b/src/mapper/types.ts
@@ -11,4 +11,6 @@ export type MapperSharedType = {
     preDialog: { [label: string]: { text: string; glue: boolean } };
     du?: NativeFunctions | ReadCount;
     params?: object;
+    /** Known character ids, checked alongside `RegisteredCharacters` when splitting `id: text` speakers. */
+    characterIds?: ReadonlySet<string>;
 };

--- a/src/vite-listener/index.ts
+++ b/src/vite-listener/index.ts
@@ -1,1 +1,1 @@
-export { setupInkHmrListener } from "./plugins";
+export { type InkHmrListenerOptions, setupInkHmrListener } from "./plugins";

--- a/src/vite-listener/plugins.ts
+++ b/src/vite-listener/plugins.ts
@@ -1,5 +1,6 @@
 /// <reference types="vite/client" />
 import { importInkText, importJson } from "@/loader/importer";
+import type { CharacterIdSource } from "@/loader/type";
 import type { PixiVNJson } from "@drincs/pixi-vn-json";
 import { inkJsons } from "virtual:pixi-vn-ink";
 
@@ -13,22 +14,33 @@ type InkUpdatedPayloadHandlers = {
     importInkText: (inkText: string) => Promise<unknown>;
 };
 
+/** Options for the Ink HMR listener helpers. */
+export type InkHmrListenerOptions = {
+    /**
+     * Characters forwarded to {@link importInkText} when an update re-imports raw Ink text (the path
+     * used without `inkJsonOutputPattern`), so `characterId: text` speakers resolve at reload time.
+     */
+    characters?: readonly CharacterIdSource[];
+};
+
 export async function handleInkUpdatedPayload(
     payload: string | InkUpdatedPayload,
-    handlers: InkUpdatedPayloadHandlers = {
+    handlers?: InkUpdatedPayloadHandlers,
+    options: InkHmrListenerOptions = {},
+): Promise<void> {
+    const resolvedHandlers: InkUpdatedPayloadHandlers = handlers ?? {
         importJson: async (data) => {
             await importJson(data);
         },
-        importInkText,
-    },
-): Promise<void> {
+        importInkText: (inkText) => importInkText(inkText, { characters: options.characters }),
+    };
     const inkJson =
         payload && typeof payload === "object" && "inkJson" in payload
             ? payload.inkJson
             : undefined;
 
     if (inkJson && inkJson.length > 0) {
-        await handlers.importJson(inkJson);
+        await resolvedHandlers.importJson(inkJson);
         return;
     }
 
@@ -40,7 +52,7 @@ export async function handleInkUpdatedPayload(
               : undefined;
 
     if (typeof inkText === "string") {
-        await handlers.importInkText(inkText);
+        await resolvedHandlers.importInkText(inkText);
     }
 }
 
@@ -54,6 +66,8 @@ export async function handleInkUpdatedPayload(
  * is handled server-side by `vitePluginPixivn`'s `content` / `characters` /
  * `labels` options — no browser POSTs are needed.
  *
+ * @param options.characters characters forwarded to {@link importInkText} on the raw-text reload
+ * path (see {@link InkHmrListenerOptions})
  * @see https://pixi-vn.com/ink#vite-plugin
  * @example
  * ```ts title="main.ts"
@@ -77,14 +91,14 @@ export async function handleInkUpdatedPayload(
  * await setupInkHmrListener();
  * ```
  */
-export async function setupInkHmrListener() {
+export async function setupInkHmrListener(options: InkHmrListenerOptions = {}) {
     if (import.meta.hot) {
         if (inkJsons && inkJsons.length > 0) {
             await importJson(inkJsons);
         }
 
         import.meta.hot.on("ink-updated", async (payload: string | InkUpdatedPayload) => {
-            await handleInkUpdatedPayload(payload);
+            await handleInkUpdatedPayload(payload, undefined, options);
         });
 
         import.meta.hot.on("ink-error-cleared", () => {

--- a/src/vite/plugins.ts
+++ b/src/vite/plugins.ts
@@ -24,6 +24,8 @@ const INK_EXTERNAL_LABELS_PROVIDER_ID = "ink";
 
 type PixivnPluginApi = {
     contentLoaded?: Promise<void>;
+    /** Characters registered by `vite-plugin-pixi-vn`, populated after {@link contentLoaded}. */
+    characters?: readonly { id: string }[];
     onReload?: (cb: () => void) => void;
     setExternalLabels?: (
         providerId: string,
@@ -251,6 +253,14 @@ export interface VitePluginInkOptions {
      * @example "./generated/manifest.json"
      */
     inkJsonManifestPath?: string;
+    /**
+     * Character ids to recognise when splitting `characterId: text` speakers in `.ink` files.
+     * Characters from `vite-plugin-pixi-vn` (its `api.characters`) are picked up automatically;
+     * use this to supply ids explicitly when it is not present.
+     *
+     * @example ["alice", "james"]
+     */
+    characters?: readonly string[];
 }
 
 function readBody(req: IncomingMessage): Promise<string> {
@@ -344,7 +354,7 @@ function readBody(req: IncomingMessage): Promise<string> {
  * ```
  */
 export function vitePluginInk(options?: VitePluginInkOptions): Plugin {
-    const { inkGlob, inkJsonOutputPattern, inkJsonManifestPath } = options ?? {};
+    const { inkGlob, inkJsonOutputPattern, inkJsonManifestPath, characters } = options ?? {};
     const hasInkJsonManifestMode = Boolean(inkJsonOutputPattern);
     let resolvedConfig: ResolvedConfig | undefined;
     let hashtagCommandsStore: InkHashtagCommandInfo[] = [];
@@ -505,13 +515,21 @@ export function vitePluginInk(options?: VitePluginInkOptions): Plugin {
         const localJsonData: PixiVNJson[] = [];
         const generatedJsonFiles = new Set<string>();
 
+        // Character ids known at conversion time: the `characters` option plus those exposed by
+        // `vite-plugin-pixi-vn` via `api.characters`.
+        const pixivnCharacters = getPixivnPlugin(resolvedConfig.plugins)?.api?.characters ?? [];
+        const knownCharacters: (string | { id: string })[] = [
+            ...(characters ?? []),
+            ...pixivnCharacters,
+        ];
+
         await fs.mkdir(outputDirectory, { recursive: true });
 
         for (const matchedFile of matchedFiles) {
             const source = await fs.readFile(matchedFile, "utf-8");
             let converted: ReturnType<typeof convertInkToJson>;
             try {
-                converted = convertInkToJson(source);
+                converted = convertInkToJson(source, { characters: knownCharacters });
             } catch (error) {
                 const normalizedError = error instanceof Error ? error : new Error(String(error));
                 resolvedConfig.logger.error(

--- a/tests/character-at-conversion.test.ts
+++ b/tests/character-at-conversion.test.ts
@@ -1,0 +1,88 @@
+import { convertInkToJson } from "@/loader";
+import { CharacterBaseModel, RegisteredCharacters } from "@drincs/pixi-vn";
+import { describe, expect, test } from "vitest";
+
+/**
+ * Regression tests for #123: `characterId: text` speakers must resolve when the characters are
+ * passed to the converter, even if they are not in the global `RegisteredCharacters` registry.
+ * The ids used here (`bob`, `zoe`) are intentionally never registered globally in the suite.
+ */
+describe("#123 resolve characterId speaker when characters are passed to the converter", () => {
+    test("attaches the character even though it is NOT in RegisteredCharacters", () => {
+        expect(RegisteredCharacters.has("bob")).toBe(false);
+
+        const res = convertInkToJson(`\n=== start ===\nbob: Hi\n-> DONE\n`, {
+            characters: ["bob"],
+        });
+
+        expect(res?.labels?.start[0].dialogue).toEqual({ character: "bob", text: "Hi" });
+    });
+
+    test("accepts character-like objects (e.g. RegisteredCharacters.values())", () => {
+        expect(RegisteredCharacters.has("zoe")).toBe(false);
+
+        const res = convertInkToJson(`\n=== start ===\nzoe: Hello there.\n-> DONE\n`, {
+            characters: [{ id: "zoe" }],
+        });
+
+        expect(res?.labels?.start[0].dialogue).toEqual({ character: "zoe", text: "Hello there." });
+    });
+
+    test("keeps the first ': ' split so a sentence with extra colons stays intact", () => {
+        const res = convertInkToJson(`\n=== start ===\nbob: I see it: a clue.\n-> DONE\n`, {
+            characters: ["bob"],
+        });
+
+        expect(res?.labels?.start[0].dialogue).toEqual({
+            character: "bob",
+            text: "I see it: a clue.",
+        });
+    });
+
+    test("does NOT split an unknown prefix (no false-positive speaker on plain colons)", () => {
+        const res = convertInkToJson(`\n=== start ===\nNote: remember this\n-> DONE\n`, {
+            characters: ["bob"],
+        });
+
+        // "Note" is not a known character, so the line stays a narrator line, prefix included.
+        expect(res?.labels?.start[0].dialogue).toBe("Note: remember this");
+    });
+
+    test("without the option and without a global registration, the prefix is left as text", () => {
+        // Documents the pre-fix behaviour: nothing knows about `bob`, so no split happens.
+        expect(RegisteredCharacters.has("bob")).toBe(false);
+
+        const res = convertInkToJson(`\n=== start ===\nbob: Hi\n-> DONE\n`);
+
+        expect(res?.labels?.start[0].dialogue).toBe("bob: Hi");
+    });
+
+    test("still honours the global RegisteredCharacters registry (no regression)", () => {
+        const carol = new CharacterBaseModel("carol", { name: "Carol" });
+        RegisteredCharacters.add(carol);
+
+        const res = convertInkToJson(`\n=== start ===\ncarol: Hi\n-> DONE\n`);
+
+        expect(res?.labels?.start[0].dialogue).toEqual({ character: "carol", text: "Hi" });
+    });
+
+    test("merges the passed characters with the global registry", () => {
+        const dave = new CharacterBaseModel("dave", { name: "Dave" });
+        RegisteredCharacters.add(dave);
+        expect(RegisteredCharacters.has("bob")).toBe(false);
+
+        const res = convertInkToJson(
+            `\n=== start ===\ndave: From the registry.\nbob: From the option.\n-> DONE\n`,
+            { characters: ["bob"] },
+        );
+
+        expect(res?.labels?.start[0].dialogue).toEqual({
+            character: "dave",
+            text: "From the registry.",
+        });
+        expect(res?.labels?.start[1].dialogue).toEqual({
+            character: "bob",
+            text: "From the option.",
+        });
+    });
+});

--- a/tests/vite-listener.test.ts
+++ b/tests/vite-listener.test.ts
@@ -1,6 +1,12 @@
+import { importInkText } from "@/loader/importer";
 import { handleInkUpdatedPayload } from "@/vite-listener/plugins";
 import type { PixiVNJson } from "@drincs/pixi-vn-json";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/loader/importer", () => ({
+    importInkText: vi.fn(async () => []),
+    importJson: vi.fn(async () => {}),
+}));
 
 describe("vite-listener HMR payload handling", () => {
     it("imports JSON directly when payload contains inkJson", async () => {
@@ -35,5 +41,16 @@ describe("vite-listener HMR payload handling", () => {
 
         expect(importInkText).toHaveBeenCalledWith("=== start ===\nHello!\n");
         expect(importJson).not.toHaveBeenCalled();
+    });
+
+    // Regression for #123: the raw-inkText HMR fallback forwards the `characters` option to importInkText.
+    it("forwards the characters option to the default importInkText for raw inkText", async () => {
+        const importInkTextMock = vi.mocked(importInkText);
+        importInkTextMock.mockClear();
+        const characters = [{ id: "bob" }];
+
+        await handleInkUpdatedPayload("=== start ===\nbob: Hi\n", undefined, { characters });
+
+        expect(importInkTextMock).toHaveBeenCalledWith("=== start ===\nbob: Hi\n", { characters });
     });
 });

--- a/tests/vite-plugin.test.ts
+++ b/tests/vite-plugin.test.ts
@@ -296,6 +296,76 @@ describe("vitePluginInk", () => {
         );
     });
 
+    // Regression for #123: the build/dev converter resolves `characterId: text` speakers from
+    // `vite-plugin-pixi-vn` `api.characters` and the `characters` option. Asserted via the in-memory
+    // virtual module (load) to stay independent of on-disk JSON output.
+    it("resolves characterId speakers from vite-plugin-pixi-vn api.characters at build time", async () => {
+        const root = await createTempProject();
+        tempDirectories.push(root);
+
+        await fs.mkdir(path.join(root, "ink"), { recursive: true });
+        await fs.mkdir(path.join(root, "public"), { recursive: true });
+        await fs.writeFile(
+            path.join(root, "ink", "start.ink"),
+            "=== start ===\nbob: Hi\n-> DONE\n",
+            "utf-8",
+        );
+
+        const plugin = vitePluginInk({
+            inkGlob: "./ink/**/*.ink",
+            inkJsonOutputPattern: "./public/ink-json/[path][name].json",
+        });
+
+        plugin.configResolved?.(
+            makeResolvedConfig(root, path.join(root, "public"), makeLogger(), [
+                {
+                    name: "vite-plugin-pixi-vn",
+                    api: {
+                        contentLoaded: Promise.resolve(),
+                        characters: [{ id: "bob" }],
+                    },
+                },
+            ]),
+        );
+
+        await plugin.buildStart?.call(undefined);
+        const loaded = await plugin.load?.("\0virtual:pixi-vn-ink");
+
+        expect(loaded).toContain('"character":"bob"');
+        expect(loaded).toContain('"text":"Hi"');
+        // The literal "bob: Hi" prefix must NOT be baked into the dialogue text.
+        expect(loaded).not.toContain("bob: Hi");
+    });
+
+    it("resolves characterId speakers from the explicit characters option at build time", async () => {
+        const root = await createTempProject();
+        tempDirectories.push(root);
+
+        await fs.mkdir(path.join(root, "ink"), { recursive: true });
+        await fs.mkdir(path.join(root, "public"), { recursive: true });
+        await fs.writeFile(
+            path.join(root, "ink", "start.ink"),
+            "=== start ===\nbob: Hi\n-> DONE\n",
+            "utf-8",
+        );
+
+        const plugin = vitePluginInk({
+            inkGlob: "./ink/**/*.ink",
+            inkJsonOutputPattern: "./public/ink-json/[path][name].json",
+            characters: ["bob"],
+        });
+
+        // No vite-plugin-pixi-vn present: the explicit option is the only character source.
+        plugin.configResolved?.(makeResolvedConfig(root, path.join(root, "public")));
+
+        await plugin.buildStart?.call(undefined);
+        const loaded = await plugin.load?.("\0virtual:pixi-vn-ink");
+
+        expect(loaded).toContain('"character":"bob"');
+        expect(loaded).toContain('"text":"Hi"');
+        expect(loaded).not.toContain("bob: Hi");
+    });
+
     it("rejects inkGlob patterns that escape project root", async () => {
         const plugin = vitePluginInk({
             inkGlob: "../**/*.ink",


### PR DESCRIPTION
Fixes #123.

## Problem

An Ink line using the documented `characterId: text` speaker syntax was not attached to the character when the ink was **converted** without that character being known to the converter — `narration.dialogue` became `{ text: "id: text", character: undefined }`, leaving the `id:` prefix in the printed text and rendering no name/color.

The speaker split in `getDialog` (`src/mapper/adding-elements.ts`) was gated solely on the global `RegisteredCharacters` registry, which is empty in:

- **build/dev** — `vitePluginInk` runs the converter in a separate Node module graph from `vitePluginPixivn` (which registers the characters), so it baked `"id: …"` into the emitted JSON; and
- **runtime** — `importInkText` running before `RegisteredCharacters.add(...)`.

## Approach

Give the converter the character list, checked **in addition to** `RegisteredCharacters` (so existing behavior is preserved and the gate still disambiguates a real speaker from a sentence that merely contains `": "`):

- Thread an optional `characterIds` set through `convertInkToJson → mapper → getDialog`.
- `vitePluginInk` picks up `vite-plugin-pixi-vn`'s registered characters automatically via its `api.characters`, plus a new explicit `characters` option.
- `convertInkToJson` / `importInkText` / `setupInkHmrListener` accept an optional `characters` option for the runtime / no-`vite-plugin-pixi-vn` paths.

This restores the build-time character sync that previously existed (06a2245) and was dropped in debfa1f, now sourced from the supported `api.characters` getter rather than mutating the registry.

### Why not lazy display-time resolution?

It was considered but rejected: an unregistered prefix resolves to the raw id string at runtime (`getCharacter(id) || id`), so always-splitting would mis-attribute non-speaker lines like `Note: text` (→ speaker "Note", prefix stripped). The known-character gate is required, and there is no display-time hook in pixi-vn-ink (the translator pipeline is text→text only). Keeping the decision at conversion time — but giving the converter the right character set — is the minimal correct fix and lives entirely in `pixi-vn-ink`.

## User impact — no breaking changes

Everything added is optional. For the standard template (both plugins wired) the fix is transparent: update and rebuild. New opt-in surface:

- `vitePluginInk({ characters })`
- `convertInkToJson(text, { characters })`, `importInkText(texts, { characters })`
- `setupInkHmrListener({ characters })`
- exported types `CharacterIdSource`, `InkHmrListenerOptions`

Suggest releasing as a **minor** (additive options) even though it is fundamentally a bug fix.

## Testing

- New converter-level regression tests (`tests/character-at-conversion.test.ts`) — fail before the change, pass after.
- New build-path tests (`tests/vite-plugin.test.ts`) via the in-memory virtual module (both `api.characters` and the explicit option).
- New HMR forwarding test (`tests/vite-listener.test.ts`).
- Verified end-to-end with the playground build (real `vitePluginPixivn`): emitted JSON now contains `{ "character": "alice", "text": "…" }` instead of the baked `alice:` prefix.

> Separate, pre-existing issue (not addressed here): on Windows, `exportInkJsonFiles`' stale-file cleanup compares `path.normalize` (backslash) paths against `tinyglobby` `absolute: true` (forward-slash) paths, so freshly-generated JSON is deleted — the same 6 `vite-plugin.test.ts` cases fail on `main` on Windows too. Unrelated to this change; happy to open a separate PR (one-liner: compare `path.resolve`d paths).
